### PR TITLE
Fixed issue #47

### DIFF
--- a/service/ldsv3/api-configurations.go
+++ b/service/ldsv3/api-configurations.go
@@ -63,11 +63,15 @@ func (lds *Ldsv3) UpdateLogConfiguration(logConfigurationID string, body Configu
 	}
 
 	headers := resp.Header()
-
-	fmt.Println(headers)
 	location := headers.Get("Location")
 
-	return location, nil
+	configurationURL, err := url.Parse(location)
+
+	if err != nil {
+		return location, err
+	}
+
+	return path.Base(configurationURL.Path), nil
 }
 
 // RemoveLogConfiguration deletes a specific log delivery configuration.


### PR DESCRIPTION
https://github.com/apiheat/go-edgegrid/issues/47

UpdateLogConfiguration will return now Configuration ID (string) and error, as other functions(CopyLogConfiguration, CreateLogConfiguration) do.